### PR TITLE
Css spread in jsx

### DIFF
--- a/transforms/__testfixtures__/radium-to-glamor/inline-style-to-component.output.js
+++ b/transforms/__testfixtures__/radium-to-glamor/inline-style-to-component.output.js
@@ -10,18 +10,18 @@ const InlineStyles = React.createClass({
     },
 
     getStyles() {
-        return css({
+        return {
             borderWidth: 1,
             borderColor: "red",
             borderStyle: "solid",
-        });
+        };
     },
 
     render() {
         const { ComponentClass } = this.props;
 
         return (
-            <div {...this.getStyles()}>
+            <div {...css(this.getStyles())}>
                 <Button style={{ background: "blue" }}>
                     Hello
                 </Button>

--- a/transforms/__testfixtures__/radium-to-glamor/inline-styles.input.js
+++ b/transforms/__testfixtures__/radium-to-glamor/inline-styles.input.js
@@ -23,16 +23,11 @@ const InlineStyles = React.createClass({
     },
 
     render() {
-        const heyWidth = this.getStyles().width;
-
         return (
             <div style={this.getStyles()}>
                 <div style={this.props.style}>
                     <span style={{ background: "blue" }}>
                         Hello
-                    </span>
-                    <span style={{ width: heyWidth }}>
-                        world
                     </span>
                 </div>
             </div>

--- a/transforms/__testfixtures__/radium-to-glamor/inline-styles.input.js
+++ b/transforms/__testfixtures__/radium-to-glamor/inline-styles.input.js
@@ -1,3 +1,4 @@
+import { css } from "glamor";
 import React from "react";
 import Radium from "radium";
 
@@ -25,7 +26,7 @@ const InlineStyles = React.createClass({
     render() {
         return (
             <div style={this.getStyles()}>
-                <div style={this.props.style}>
+                <div {...css(this.props.style)}>
                     <span style={{ background: "blue" }}>
                         Hello
                     </span>

--- a/transforms/__testfixtures__/radium-to-glamor/inline-styles.output.js
+++ b/transforms/__testfixtures__/radium-to-glamor/inline-styles.output.js
@@ -1,4 +1,3 @@
-// TODO_RADIUM_TO_GLAMOR - call to this.getStyles outside of style prop needs to be looked at
 import { css } from "glamor";
 import React from "react";
 
@@ -17,23 +16,18 @@ const InlineStyles = React.createClass({
             width: 100,
         };
 
-        return css([
+        return [
             styles,
             this.props.style,
-        ]);
+        ];
     },
 
     render() {
-        const heyWidth = this.getStyles().width;
-
         return (
-            <div {...this.getStyles()}>
+            <div {...css(this.getStyles())}>
                 <div {...css(this.props.style)}>
                     <span {...css({ background: "blue" })}>
                         Hello
-                    </span>
-                    <span {...css({ width: heyWidth })}>
-                        world
                     </span>
                 </div>
             </div>

--- a/transforms/radium-to-glamor.js
+++ b/transforms/radium-to-glamor.js
@@ -82,7 +82,6 @@ export default function transformer(file, api) {
         },
     })
     .filter(isJSXAttributeOfDOMComponent)
-    .filter((path) => path.value.value.expression.type !== "CallExpression")
     .forEach((path) => {
         cssCallCounter += 1;
         j(path).replaceWith(
@@ -127,56 +126,7 @@ export default function transformer(file, api) {
     );
   });
 
-
-  // Find style function calls outside
-    styleFunctions.forEach((styleFunction) => {
-        source.find(j.CallExpression, {
-            callee: {
-                type: "MemberExpression",
-                object: {
-                    type: "ThisExpression",
-                },
-                property: {
-                    type: "Identifier",
-                    name: styleFunction,
-                },
-            },
-        })
-    .filter((path) => path.parent.value.type !== "JSXSpreadAttribute")
-    .forEach(() => {
-        insertAtTopOfFile(source, j, `// TODO_RADIUM_TO_GLAMOR - call to this.${styleFunction} outside of style prop needs to be looked at`);
-    });
-    });
-
-  // Add css function to all style function return statements
-    source
-    .find(j.CallExpression, {
-        callee: {
-            type: "MemberExpression",
-            property: {
-                name: "createClass",
-            },
-        },
-    }).forEach((path) => {
-        j(path).find(j.Property).forEach((property) => {
-            const identifier = property.value.key.name;
-            if (styleFunctions.indexOf(identifier) >= 0) {
-                cssCallCounter++;
-                j(property).find(j.ReturnStatement).forEach((returnStatement) => {
-                    j(returnStatement).replaceWith(
-              j.returnStatement(
-                j.callExpression(
-                   j.identifier("css"),
-                   [returnStatement.value.argument]
-                )
-              )
-            );
-                });
-            }
-        });
-    });
-
-
+  // keyframes
     source.find(j.CallExpression, {
         callee: {
             type: "MemberExpression",

--- a/transforms/radium-to-glamor.js
+++ b/transforms/radium-to-glamor.js
@@ -21,6 +21,7 @@ export default function transformer(file, api) {
     const j = api.jscodeshift;
 
     const source = j(file.source);
+    const defaultImports = [];
     let cssCallCounter = 0;
 
 
@@ -38,8 +39,7 @@ export default function transformer(file, api) {
     });
 
 
-  // find all the imports
-    const imports = [];
+  // find all the defaultImports
     source
     .find(j.ImportDefaultSpecifier, {
         type: "ImportDefaultSpecifier",
@@ -48,7 +48,7 @@ export default function transformer(file, api) {
         },
     })
     .forEach((path) => {
-        imports.push(path.value.local.name);
+        defaultImports.push(path.value.local.name);
     });
 
 
@@ -63,7 +63,7 @@ export default function transformer(file, api) {
     .forEach((path) => {
         const identifier = path.parent.value.name.name;
 
-        if (identifier == null || (imports.indexOf(identifier) < 0 && isCapitalized(identifier))) {
+        if (identifier == null || defaultImports.indexOf(identifier) < 0 && isCapitalized(identifier)) {
             const text = `// TODO_RADIUM_TO_GLAMOR - JSX refers to ${identifier}, which is a variable. So wanted behaviour unknown.`;
             insertAtTopOfFile(source, j, text);
         }

--- a/transforms/radium-to-glamor.js
+++ b/transforms/radium-to-glamor.js
@@ -16,6 +16,15 @@ function insertAtTopOfFile(source, j, nodeToBeInserted) {
     .insertBefore(nodeToBeInserted);
 }
 
+function hasGlamorImport(source, j) {
+  return source.find(j.ImportDeclaration, {
+    source: {
+      type: 'Literal',
+      value: 'glamor',
+    }
+  }).length > 0;
+}
+
 
 export default function transformer(file, api) {
     const j = api.jscodeshift;
@@ -148,9 +157,10 @@ export default function transformer(file, api) {
 
 
   // import glamor where needed
-    if (cssCallCounter > 0) {
+    if (cssCallCounter > 0 && !hasGlamorImport(source, j)) {
         insertAtTopOfFile(source, j, "import { css } from \"glamor\";");
     }
+
 
   // Remove Radium import
     source

--- a/transforms/radium-to-glamor.js
+++ b/transforms/radium-to-glamor.js
@@ -94,38 +94,6 @@ export default function transformer(file, api) {
       );
     });
 
-
-  // Find all style functions
-    const styleFunctions = [];
-    source
-  .find(j.JSXAttribute, {
-      name: {
-          type: "JSXIdentifier",
-          name: "style",
-      },
-      value: {
-          type: "JSXExpressionContainer",
-          expression: {
-              type: "CallExpression",
-              callee: {
-                  type: "MemberExpression",
-                  property: {
-                      type: "Identifier",
-                  },
-              },
-          },
-      },
-  })
- .filter(isJSXAttributeOfDOMComponent)
-  .forEach((path) => {
-      const functionName = path.value.value.expression.callee.property.name;
-      styleFunctions.push(functionName);
-
-      j(path).replaceWith(
-      j.jsxSpreadAttribute(path.node.value.expression)
-    );
-  });
-
   // keyframes
     source.find(j.CallExpression, {
         callee: {


### PR DESCRIPTION
This moves the css({ blah }) from the styles functions and into the JSX.

Everywhere where `style={blah}` get's passed into a DOM element will now be changed to `{...css({blah})}` . 

Also made a small change to ensure that the codemod can be ran multiple times over the same codebase (don't import glamor multiple times)