### PR TITLE
warn about potential issues of passing bad style prop to DOM elements

### DIFF
--- a/transforms/__testfixtures__/radium-to-glamor/inline-styles.input.js
+++ b/transforms/__testfixtures__/radium-to-glamor/inline-styles.input.js
@@ -26,7 +26,7 @@ const InlineStyles = React.createClass({
     render() {
         return (
             <div style={this.getStyles()}>
-                <div {...css(this.props.style)}>
+                <div {...css({ marginLeft: 10 })}>
                     <span style={{ background: "blue" }}>
                         Hello
                     </span>

--- a/transforms/__testfixtures__/radium-to-glamor/inline-styles.output.js
+++ b/transforms/__testfixtures__/radium-to-glamor/inline-styles.output.js
@@ -25,7 +25,7 @@ const InlineStyles = React.createClass({
     render() {
         return (
             <div {...css(this.getStyles())}>
-                <div {...css(this.props.style)}>
+                <div {...css({ marginLeft: 10 })}>
                     <span {...css({ background: "blue" })}>
                         Hello
                     </span>

--- a/transforms/__testfixtures__/radium-to-glamor/this-props-spread.input.js
+++ b/transforms/__testfixtures__/radium-to-glamor/this-props-spread.input.js
@@ -1,0 +1,44 @@
+import React from "react";
+import Radium from "radium";
+import OtherComponent from "./OtherComponent";
+
+const Spreader = React.createClass({
+
+    render() {
+        const { ComponentClass, OtherClass } = this.props; // eslint-disable-line react/prop-types
+
+        return (
+            <ComponentClass
+                {...this.props}
+                style={this.getStyles()}
+            >
+                <div
+                    {...this.props}
+                    style={this.getDivStyles()}
+                >
+                    DANGER BECAUSE DOM
+                </div>
+                <OtherComponent
+                    {...this.props}
+                    style={this.getDivStyles()}
+                >
+                    NO DANGER - NO MESSAGE
+                </OtherComponent>
+                <li
+                    {...this.props}
+                    otherProp={true}
+                >
+                  NO DANGER BECAUSE NO STYLE
+                </li>
+                <OtherClass
+                    {...this.props}
+                    otherProp={true}
+                >
+                  NO DANGER BECAUSE NO STYLE
+                </OtherClass>
+            </ComponentClass>
+        );
+    },
+});
+
+export default Radium(Spreader);

--- a/transforms/__testfixtures__/radium-to-glamor/this-props-spread.input.js
+++ b/transforms/__testfixtures__/radium-to-glamor/this-props-spread.input.js
@@ -28,13 +28,13 @@ const Spreader = React.createClass({
                     {...this.props}
                     otherProp={true}
                 >
-                  NO DANGER BECAUSE NO STYLE
+                    DANGER BECAUSE DOM AND SPREAD
                 </li>
                 <OtherClass
                     {...this.props}
                     otherProp={true}
                 >
-                  NO DANGER BECAUSE NO STYLE
+                    DANGER BECAUSE VARIABLE AND SPREAD
                 </OtherClass>
             </ComponentClass>
         );

--- a/transforms/__testfixtures__/radium-to-glamor/this-props-spread.output.js
+++ b/transforms/__testfixtures__/radium-to-glamor/this-props-spread.output.js
@@ -1,0 +1,44 @@
+// TODO_RADIUM_TO_GLAMOR - JSX refers to ComponentClass, which is a variable. So wanted behaviour unknown.
+// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, ComponentClass, contains a spread which references this.props, followed by a style prop. It's not safe to assume that this is safe because the style prop has been removed
+// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, div, contains a spread which references this.props, followed by a style prop. It's not safe to assume that this is safe because the style prop has been removed
+import { css } from "glamor";
+import React from "react";
+import OtherComponent from "./OtherComponent";
+
+const Spreader = React.createClass({
+
+    render() {
+        const { ComponentClass, OtherClass } = this.props; // eslint-disable-line react/prop-types
+
+        return (
+            <ComponentClass
+                {...this.props}
+                style={this.getStyles()}
+            >
+                <div {...this.props} {...css(this.getDivStyles())}>
+                    DANGER BECAUSE DOM
+                </div>
+                <OtherComponent
+                    {...this.props}
+                    style={this.getDivStyles()}
+                >
+                    NO DANGER - NO MESSAGE
+                </OtherComponent>
+                <li
+                    {...this.props}
+                    otherProp={true}
+                >
+                  NO DANGER BECAUSE NO STYLE
+                </li>
+                <OtherClass
+                    {...this.props}
+                    otherProp={true}
+                >
+                  NO DANGER BECAUSE NO STYLE
+                </OtherClass>
+            </ComponentClass>
+        );
+    },
+});
+
+export default Spreader;

--- a/transforms/__testfixtures__/radium-to-glamor/this-props-spread.output.js
+++ b/transforms/__testfixtures__/radium-to-glamor/this-props-spread.output.js
@@ -1,6 +1,8 @@
 // TODO_RADIUM_TO_GLAMOR - JSX refers to ComponentClass, which is a variable. So wanted behaviour unknown.
-// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, ComponentClass, contains a spread which references this.props, followed by a style prop. It's not safe to assume that this is safe because the style prop has been removed
-// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, div, contains a spread which references this.props, followed by a style prop. It's not safe to assume that this is safe because the style prop has been removed
+// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, ComponentClass, contains a spread which references this.props. It's not safe to assume that this is safe because it might contain a style prop that'll no longer be reconciled by Radium
+// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, div, contains a spread which references this.props. It's not safe to assume that this is safe because it might contain a style prop that'll no longer be reconciled by Radium
+// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, li, contains a spread which references this.props. It's not safe to assume that this is safe because it might contain a style prop that'll no longer be reconciled by Radium
+// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, OtherClass, contains a spread which references this.props. It's not safe to assume that this is safe because it might contain a style prop that'll no longer be reconciled by Radium
 import { css } from "glamor";
 import React from "react";
 import OtherComponent from "./OtherComponent";
@@ -28,13 +30,13 @@ const Spreader = React.createClass({
                     {...this.props}
                     otherProp={true}
                 >
-                  NO DANGER BECAUSE NO STYLE
+                    DANGER BECAUSE DOM AND SPREAD
                 </li>
                 <OtherClass
                     {...this.props}
                     otherProp={true}
                 >
-                  NO DANGER BECAUSE NO STYLE
+                    DANGER BECAUSE VARIABLE AND SPREAD
                 </OtherClass>
             </ComponentClass>
         );

--- a/transforms/__tests__/radium-to-glamor-test.js
+++ b/transforms/__tests__/radium-to-glamor-test.js
@@ -3,7 +3,8 @@ const tests = [
     "inline-style-to-component",
     "get-state",
     "keyframes",
-    "es6-class"
+    "es6-class",
+    "this-props-spread",
 ];
 
 const defineTest = require("jscodeshift/dist/testUtils").defineTest;

--- a/transforms/radium-to-glamor.js
+++ b/transforms/radium-to-glamor.js
@@ -4,9 +4,18 @@ function isCapitalized(node) {
     return firstCharacter.toUpperCase() === firstCharacter;
 }
 
+function getJSXComponentNameFromAttributePath(path) {
+    return path.parent.value.name.name;
+}
+
 function isJSXAttributeOfDOMComponent(path) {
-    const identifier = path.parent.value.name.name;
-    return identifier != null && !isCapitalized(identifier);
+    const name = getJSXComponentNameFromAttributePath(path);
+    return name != null && !isCapitalized(name);
+}
+
+function isJSXAttributeOfVariableComponent(path, defaultImports) {
+    const name = getJSXComponentNameFromAttributePath(path);
+    return name == null || (defaultImports.indexOf(name) < 0 && isCapitalized(name));
 }
 
 function insertAtTopOfFile(source, j, nodeToBeInserted) {
@@ -70,10 +79,46 @@ export default function transformer(file, api) {
         },
     })
     .forEach((path) => {
-        const identifier = path.parent.value.name.name;
-
-        if (identifier == null || defaultImports.indexOf(identifier) < 0 && isCapitalized(identifier)) {
+        if (isJSXAttributeOfVariableComponent(path, defaultImports)) {
+            const identifier = getJSXComponentNameFromAttributePath(path);
             const text = `// TODO_RADIUM_TO_GLAMOR - JSX refers to ${identifier}, which is a variable. So wanted behaviour unknown.`;
+            insertAtTopOfFile(source, j, text);
+        }
+    });
+
+  // Find any spread of this.props that can't be statically analysed and warn about it
+    source
+    .find(j.JSXSpreadAttribute)
+    .filter((path) => (
+        isJSXAttributeOfDOMComponent(path) ||
+        isJSXAttributeOfVariableComponent(path, defaultImports)
+    ))
+    .forEach((path) => {
+        const thisPropsDescendents = j(path).find(j.MemberExpression, {
+            object: {
+                type: "ThisExpression",
+            },
+            property: {
+                type: "Identifier",
+                name: "props",
+            },
+        });
+
+        if (thisPropsDescendents.length === 0) {
+            return;
+        }
+
+        const siblingAttributes = path.parentPath.node.attributes;
+        const indexOfSpread = siblingAttributes.indexOf(path.value);
+        const postSpreadSiblings = siblingAttributes.slice(indexOfSpread + 1);
+        const styleAttributesPostSpread = j(postSpreadSiblings).filter((siblingPath) => {
+            const { value } = siblingPath;
+            return value.type === "JSXAttribute" && value.name.name === "style";
+        });
+
+        if (styleAttributesPostSpread.length > 0) {
+            const componentName = path.parentPath.node.name.name;
+            const text = `// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, ${componentName}, contains a spread which references this.props, followed by a style prop. It's not safe to assume that this is safe because the style prop has been removed`;
             insertAtTopOfFile(source, j, text);
         }
     });

--- a/transforms/radium-to-glamor.js
+++ b/transforms/radium-to-glamor.js
@@ -108,19 +108,11 @@ export default function transformer(file, api) {
             return;
         }
 
-        const siblingAttributes = path.parentPath.node.attributes;
-        const indexOfSpread = siblingAttributes.indexOf(path.value);
-        const postSpreadSiblings = siblingAttributes.slice(indexOfSpread + 1);
-        const styleAttributesPostSpread = j(postSpreadSiblings).filter((siblingPath) => {
-            const { value } = siblingPath;
-            return value.type === "JSXAttribute" && value.name.name === "style";
-        });
 
-        if (styleAttributesPostSpread.length > 0) {
-            const componentName = path.parentPath.node.name.name;
-            const text = `// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, ${componentName}, contains a spread which references this.props, followed by a style prop. It's not safe to assume that this is safe because the style prop has been removed`;
-            insertAtTopOfFile(source, j, text);
-        }
+        const componentName = path.parentPath.node.name.name;
+        const text = `// TODO_RADIUM_TO_GLAMOR - In JSX the props for component, ${componentName}, contains a spread which references this.props. It's not safe to assume that this is safe because it might contain a style prop that'll no longer be reconciled by Radium`;
+        insertAtTopOfFile(source, j, text);
+
     });
 
 


### PR DESCRIPTION
This adds a warning whenever there's a potentially dangerous spread of `this.props` followed by a `style` prop, on either a DOM component, or a variable. We need this because the `style` prop would previously override any `style` prop that came from the parent component, and Radium would resolve that into something the DOM can handle. Because glamor spreads data attributes, we no longer override the style prop, so in some cases we're causing errors like [TypeError: CSS2Properties doesn't have an indexed property setter for '0'](https://medium.com/@abhaytalreja/react-typeerror-css2properties-doesnt-have-an-indexed-property-setter-for-0-4acea43facd5).

We could make this more intelligent by seeing if there's a child of the style prop that mentions `this.props.style` in any way but I think that it's better to warn more readily, than to potentially mess up!

